### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ final class ProfileViewController: UIViewController {
 
     func goToLogin() {
         let loginRoute = SomeLoginRouteFromTheLoginFeatureInterface()
-        dependencies.routerService.navigate(
+        routerService.navigate(
             toRoute: loginRoute,
             fromView: self,
             presentationStyle: Push(),


### PR DESCRIPTION
On **LoginFeature** called into **ProfileFeature**, the router service reference at `goToLogin(_:)` method is wrong.